### PR TITLE
Minimize diff between entry and valuta dates

### DIFF
--- a/lib/cmxl/fields/transaction.rb
+++ b/lib/cmxl/fields/transaction.rb
@@ -60,11 +60,9 @@ module Cmxl
 
       def entry_date
         if data['entry_date'] && date
-          if date.month == 1 && date.month < to_date(data['entry_date'], date.year).month
-            to_date(data['entry_date'], date.year - 1)
-          else
-            to_date(data['entry_date'], date.year)
-          end
+          deltas = [-1, 0, 1]
+          candidates = deltas.map { |delta| to_date(data['entry_date'], date.year + delta) }
+          candidates.min_by { |candidate| (candidate - date).abs }
         end
       end
 


### PR DESCRIPTION
Because entry_date is provided as MMDD, the year is ambiguos.

This changes the heuristic for choosing the year to one that mimizes the difference (in days) between valuta date and entry date.

See also: https://github.com/railslove/cmxl/issues/28 and https://github.com/railslove/cmxl/pull/16