### PR TITLE
Fix deprecation warnings for Ruby 2.7

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,7 +80,18 @@ blocks:
             - ./cc-test-reporter before-build
             - bundle exec rspec
             - ./cc-test-reporter after-build
-
+        - name: "2.7 including Code Climate"
+          commands:
+            - checkout
+            - sem-version ruby 2.7
+            - cache restore
+            - bundle install
+            - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            - chmod +x ./cc-test-reporter
+            - cache store
+            - ./cc-test-reporter before-build
+            - bundle exec rspec
+            - ./cc-test-reporter after-build
         - name: "jruby-9.1.17.0"
           commands:
             - checkout

--- a/lib/cmxl.rb
+++ b/lib/cmxl.rb
@@ -36,9 +36,9 @@ module Cmxl
     end
 
     if options[:encoding]
-      data.encode!('UTF-8', options.delete(:encoding), options)
+      data.encode!('UTF-8', options.delete(:encoding), **options)
     else
-      data.encode!('UTF-8', options) unless options.empty?
+      data.encode!('UTF-8', **options) unless options.empty?
     end
 
     data.split(options[:statement_separator]).reject { |s| s.strip.empty? }.collect { |s| Cmxl::Statement.new(s.strip) }


### PR DESCRIPTION
👋 Been getting some deprecation warnings while upgrading to Ruby 2.7:

```
cmxl/lib/cmxl.rb:39: warning: Using the last argument as keyword parameters is deprecated
```

This PR adds ruby 2.7 to semaphore and fixes the deprecation