### PR TITLE
CI: use latest JRuby jruby-9.2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.4.10
@@ -6,4 +5,4 @@ rvm:
   - 2.6.6
   - 2.7.1
   - jruby-9.1.17.0
-  - jruby-9.2.11.1
+  - jruby-9.2.12.0


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

This PR updates the CI matrix to use latest JRuby, **9.2.12.0**.

[JRuby 9.2.12.0 release blog post](https://www.jruby.org/2020/07/01/jruby-9-2-12-0.html)