### PR TITLE
Replace rchardet19 with rchardet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.byebug_history

--- a/cmxl.gemspec
+++ b/cmxl.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~>3.0'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'byebug'
 
-  spec.add_dependency 'rchardet19'
+  spec.add_dependency 'rchardet'
 end

--- a/lib/cmxl.rb
+++ b/lib/cmxl.rb
@@ -1,6 +1,6 @@
 require 'cmxl/version'
 
-require 'rchardet19'
+require 'rchardet'
 
 require 'cmxl/field'
 require 'cmxl/statement'
@@ -31,8 +31,8 @@ module Cmxl
   def self.parse(data, options = {})
     options[:statement_separator] ||= config[:statement_separator]
     # if no encoding is provided we try to guess using CharDet
-    if options[:encoding].nil? && cd = CharDet.detect(data, silent: true)
-      options[:encoding] = cd.encoding
+    if options[:encoding].nil? && cd = CharDet.detect(data)
+      options[:encoding] = cd['encoding']
     end
 
     if options[:encoding]


### PR DESCRIPTION
Replaces rchardet19 with rchardet, which works with ruby 3.3. Specs are green, but I don't know if thats everything that needs to be considered.