### PR TITLE
Use rchardet instead of rchardet19 to use this gem with ruby 3

### DIFF
--- a/cmxl.gemspec
+++ b/cmxl.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~>3.0'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'rchardet19'
+  spec.add_dependency 'rchardet'
 end

--- a/lib/cmxl.rb
+++ b/lib/cmxl.rb
@@ -1,6 +1,6 @@
 require 'cmxl/version'
 
-require 'rchardet19'
+require 'rchardet'
 
 require 'cmxl/field'
 require 'cmxl/statement'
@@ -31,8 +31,8 @@ module Cmxl
   def self.parse(data, options = {})
     options[:statement_separator] ||= config[:statement_separator]
     # if no encoding is provided we try to guess using CharDet
-    if options[:encoding].nil? && cd = CharDet.detect(data, silent: true)
-      options[:encoding] = cd.encoding
+    if options[:encoding].nil? && cd = CharDet.detect(data)
+      options[:encoding] = cd['encoding']
     end
 
     if options[:encoding]


### PR DESCRIPTION
Use rchardet instead of rchardet19

I'm not sure if there was a specific reason this needs to be compatible with ruby19, but since that version of ruby is
not being maintained since nine years, I hope we can move to a newer version. I ran the specs with ruby 3.2 without
issue.
