### PR TITLE
feat: add expected transaction type

### DIFF
--- a/CHANGELOG.mdown
+++ b/CHANGELOG.mdown
@@ -1,5 +1,10 @@
 # NEXT release
 
+# 2.0
+- `[REFACTOR]` **DEPRECATED:** `storno?` and related methods `storno_credit`, `storno_debit`. Use `reversal?` and related methods `reversal_credit?`, `reversal_debit?` instead
+- `[BUGFIX]` **DEPRECATED:** `funds_code` method returns the `credit_debit_indicator` from the SWIFT definition. Therefore the method is deprecated in favor of `credit_debit_indicator` method
+- `[HOUSEKEEPING]` [Replace Travis CI with github actions](https://github.com/railslove/cmxl/pull/57)
+
 # 1.5.0
 
 - `[BUGFIX]` fix potential bug when generation_date is not provided in field 20 and 13 (issue: [#35](https://github.com/railslove/cmxl/issues/35) PR: [#36](https://github.com/railslove/cmxl/pull/36))

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ statements.each do |s|
     puts t.information
     puts t.description
     puts t.entry_date
-    puts t.funds_code
+    puts t.credit_debit_indicator
     puts t.credit?
     puts t.debit?
     puts t.sign # -1 if it's a debit; 1 if it's a credit

--- a/lib/cmxl/version.rb
+++ b/lib/cmxl/version.rb
@@ -1,3 +1,3 @@
 module Cmxl
-  VERSION = '1.5.0'.freeze
+  VERSION = '2.0'.freeze
 end

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -27,9 +27,12 @@ describe Cmxl do
           'bank_reference' => '025498557/000001',
           'amount_in_cents' => 162,
           'sign' => -1,
+          'credit_debit_indicator' => 'D',
           'debit' => true,
           'credit' => false,
           'storno' => false,
+          'reversal' => false,
+          'expected' => false,
           'bic' => 'HYVEDEMMXXX',
           'iban' => 'HUkkbbbsssskcccccccccccccccx',
           'name' => 'Peter Pan',
@@ -81,6 +84,7 @@ describe Cmxl do
           'sha' => '3c5e65aa3d3878b06b58b6f1ae2f3693004dfb04e3ab7119a1c1244e612293da',
           'entry_date' => Date.new(2014, 9, 2),
           'funds_code' => 'D',
+          'credit_debit_indicator' => 'D',
           'currency_letter' => 'R',
           'amount' => 1.62,
           'swift_code' => 'NTRF',
@@ -90,7 +94,9 @@ describe Cmxl do
           'sign' => -1,
           'debit' => true,
           'credit' => false,
-          'storno' => false
+          'storno' => false,
+          'reversal' => false,
+          'expected' => false,
         )
       end
     end


### PR DESCRIPTION
solves https://github.com/railslove/cmxl/issues/59

- parse transactions line that includes upcoming transactions
- deprecate the `strono` method in favor of the `reversal` method to
  match the swift naming pattern
- deprecate the `funds_code` method because the method logic reflects
  the `credit_debit_indicator` logic